### PR TITLE
Option to limit comic height

### DIFF
--- a/DailyXKCD.js
+++ b/DailyXKCD.js
@@ -142,10 +142,76 @@ Module.register("DailyXKCD",{
 		this.scrollProgress += 1;
 	},
 
+	// contains auto suspending autoIntervals
+	autoIntervals: [],
+
+	/* checkUserPresence(notification, payload, sender)
+	 * Use this method to conveniently suspend your module when no user is present.
+	 */
+	checkUserPresence: function(notification, payload, sender) {
+		if (sender && notification === "USER_PRESENCE") {
+			if (payload === true)
+			{
+				this.resumeIntervals();
+			}
+			else
+			{
+				this.suspendIntervals();
+			}
+		}
+	},
+
+	/* addAutoSuspendingInterval(callback, time)
+	 * Use instead of setInterval for automatic pause when on suspend.
+	 * The callback is executed immediately once after the user returns.
+	 */
+	addAutoSuspendingInterval: function(callback, time) {
+		var newInterval = setInterval(callback, time);
+		this.autoIntervals.push({
+			callback: callback,
+			interval: newInterval,
+			time: time
+		});
+	},
+
+	/* suspendIntervals()
+	 * This method is called when a module is hidden.
+	 */
+	suspendIntervals: function() {
+		for (var i = 0; i < this.autoIntervals.length; i++)
+		{
+			var current = this.autoIntervals[i];
+
+			if (current.interval)
+			{
+				clearInterval(current.interval);
+
+				current.interval = null;
+			}
+		}
+	},
+
+	/* resumeIntervals()
+	 * This method is called when a module is shown.
+	 */
+	resumeIntervals: function() {
+		for (var i = 0; i < this.autoIntervals.length; i++)
+		{
+			var current = this.autoIntervals[i];
+
+			if (!current.interval)
+			{
+				current.callback();
+
+				current.interval = setInterval(current.callback, current.time);
+			}
+		}
+	},
+
 	scheduleUpdate: function() {
 		var self = this;
 		
-		self.updateDom(2000);
+		self.updateDom(3000);
 		
 		setInterval(function() {
 			self.getComic();

--- a/DailyXKCD.js
+++ b/DailyXKCD.js
@@ -31,7 +31,7 @@ Module.register("DailyXKCD",{
 			this.scrollProgress = 0;
 		}
 
-		this.pause = true;
+		this.pause = false;
 	},
 	
 	// Define required scripts.

--- a/DailyXKCD.js
+++ b/DailyXKCD.js
@@ -25,7 +25,7 @@ Module.register("DailyXKCD",{
 		{
 			var self = this;
 			// scroll comic up and down
-			setInterval(function() {
+			this.addAutoSuspendingInterval(function() {
 				self.scrollComic();
 			}, 8 * 1000);
 			this.scrollProgress = 0;
@@ -63,16 +63,7 @@ Module.register("DailyXKCD",{
 	},
 
 	notificationReceived: function(notification, payload, sender) {
-		if (notification === "USER_PRESENCE") {
-			if (payload === true)
-			{
-				this.pause = false;
-			}
-			else
-			{
-				this.pause = true;
-			}
-		}
+		this.checkUserPresence(notification, payload, sender);
 	},
 	
 	// Override dom generator.
@@ -106,7 +97,7 @@ Module.register("DailyXKCD",{
 			var alttext = document.createElement("div");
 			alttext.className = this.config.altTextFont;
 			alttext.innerHTML = this.dailyComicAlt;
-			alttext.style.maxWidth = xkcd.naturalWidth + "px";
+			alttext.style.maxWidth = Math.max(xkcd.naturalWidth, 400) + "px";
 
 			wrapper.appendChild(alttext);
 		}
@@ -114,16 +105,24 @@ Module.register("DailyXKCD",{
 		return wrapper;
 	},
 	
+	/* onSuspend()
+	 * This method is called when a module is hidden.
+	 */
+	onSuspend: function() {
+		this.scrollProgress = 0;
+
+		var scrollable = document.getElementsByClassName('xkcdcontent');
+		for (var i = 0; i < scrollable.length; i++)
+		{
+			var element = scrollable[i];
+			element.style.top = 0 + "px";
+		}
+	},
+
 	/* scrollComic
 	 * Scrolls the comic down if needed
 	 */
 	scrollComic: function() {
-		if (this.pause)
-		{
-			this.scrollProgress = 0;
-			return;
-		}
-
 		var scrollable = document.getElementsByClassName('xkcdcontent');
 		for (var i = 0; i < scrollable.length; i++)
 		{

--- a/DailyXKCD.js
+++ b/DailyXKCD.js
@@ -88,7 +88,7 @@ Module.register("DailyXKCD",{
 		comicWrapper.className = "xkcdcontainer";
 		if (this.config.limitComicHeight > 0)
 		{
-			comicWrapper.style.height = this.config.limitComicHeight + "px";
+			comicWrapper.style.maxHeight = this.config.limitComicHeight + "px";
 		}
 
 		var xkcd = document.createElement("img");
@@ -106,6 +106,7 @@ Module.register("DailyXKCD",{
 			var alttext = document.createElement("div");
 			alttext.className = this.config.altTextFont;
 			alttext.innerHTML = this.dailyComicAlt;
+			alttext.style.maxWidth = xkcd.naturalWidth + "px";
 
 			wrapper.appendChild(alttext);
 		}

--- a/DailyXKCD.js
+++ b/DailyXKCD.js
@@ -51,13 +51,12 @@ Module.register("DailyXKCD",{
 	},
 	
 	socketNotificationReceived: function(notification, payload) {
-		
-		if(notification === "COMIC"){
-				Log.info(payload.img);
-				this.dailyComic = payload.img;
-				this.dailyComicTitle = payload.safe_title;
-				this.dailyComicAlt = payload.alt;
-				this.scheduleUpdate();
+		if(notification === "COMIC") {
+			Log.info(payload.img);
+			this.dailyComic = payload.img;
+			this.dailyComicTitle = payload.safe_title;
+			this.dailyComicAlt = payload.alt;
+			this.scheduleUpdate();
 		}
 		
 	},
@@ -97,7 +96,6 @@ Module.register("DailyXKCD",{
 			var alttext = document.createElement("div");
 			alttext.className = this.config.altTextFont;
 			alttext.innerHTML = this.dailyComicAlt;
-			alttext.style.maxWidth = Math.max(xkcd.naturalWidth, 400) + "px";
 
 			wrapper.appendChild(alttext);
 		}

--- a/DailyXKCD.js
+++ b/DailyXKCD.js
@@ -31,7 +31,7 @@ Module.register("DailyXKCD",{
 			this.scrollProgress = 0;
 		}
 
-		this.pause = false;
+		this.pause = true;
 	},
 	
 	// Define required scripts.
@@ -66,11 +66,11 @@ Module.register("DailyXKCD",{
 		if (notification === "USER_PRESENCE") {
 			if (payload === true)
 			{
-				this.pause = true;
+				this.pause = false;
 			}
 			else
 			{
-				this.pause = false;
+				this.pause = true;
 			}
 		}
 	},

--- a/DailyXKCD.js
+++ b/DailyXKCD.js
@@ -11,7 +11,8 @@ Module.register("DailyXKCD", {
         scrollInterval : 8000, // 8 seconds,
         scrollRatio : 0.8, // scroll by 80% of visible height,
         randomComic : false,
-        showAltText : false
+        showAltText : false,
+        showTitle : true
     },
 
     start: function() {
@@ -21,6 +22,8 @@ Module.register("DailyXKCD", {
         this.dailyComic = "";
         this.dailyComicTitle = "";
         this.dailyComicAlt = "";
+
+        this.autoIntervals = [];
 
         this.getComic();
 
@@ -84,7 +87,7 @@ Module.register("DailyXKCD", {
         title.className = this.config.titleFont;
         title.innerHTML = this.dailyComicTitle;
 
-        if (this.config.title) {
+        if (this.config.showTitle) {
             wrapper.appendChild(title);
         }
 

--- a/DailyXKCD.js
+++ b/DailyXKCD.js
@@ -4,8 +4,10 @@ Module.register("DailyXKCD",{
 	defaults: {
 		dailyJsonUrl : "http://xkcd.com/info.0.json",
 		updateInterval : 10000 * 60 * 60, // 10 hours
-		invertColors : false
-		
+		invertColors : false,
+		titleFont : "bright large light",
+		showAltText : false
+
 	},
 	
 	start: function() {
@@ -14,6 +16,7 @@ Module.register("DailyXKCD",{
 		
 		this.dailyComic = "";
 		this.dailyComicTitle = "";
+		this.dailyComicAlt = "";
 		
 		this.getComic();
 	},
@@ -35,6 +38,7 @@ Module.register("DailyXKCD",{
 				Log.info(payload.img);
 				this.dailyComic = payload.img;
 				this.dailyComicTitle = payload.safe_title;
+				this.dailyComicAlt = payload.alt;
 				this.scheduleUpdate();
 		}
 		
@@ -45,7 +49,7 @@ Module.register("DailyXKCD",{
 		var wrapper = document.createElement("div");
 		
 		var title = document.createElement("div");
-		title.className = "bright large light";
+		title.className = this.config.titleFont;
 		title.innerHTML = this.dailyComicTitle;
 		
 		var xkcd = document.createElement("img");
@@ -53,9 +57,19 @@ Module.register("DailyXKCD",{
 		if(this.config.invertColors){
 			xkcd.setAttribute("style", "-webkit-filter: invert(100%);")
 		}
-		
+
 		wrapper.appendChild(title);
 		wrapper.appendChild(xkcd);
+
+		if (this.config.showAltText)
+		{
+			var alttext = document.createElement("div");
+			alttext.className = "xsmall dimmed thin";
+			alttext.innerHTML = this.dailyComicAlt;
+
+			wrapper.appendChild(alttext);
+		}
+
 		return wrapper;
 	},
 	

--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ A module for MagicMirror<sup>2</sup> that displays the daily XKCD web comic.
 | **Option** | **Description** |
 | --- | --- |
 | `invertColors` | Set to `true` to invert the colors of the comic to white on black for a darker feel. |
+| `titleFont` | Set a custom font format, default is `large light bright`. To set the size use one of `xsmall small medium large xlarge`, for boldness one of `thin light regular bold`, and to adjust brightness one of `dimmed normal bright`. |
+| `showAltText` | Set to `true` to show the alt text (tooltip on the original comic). |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A module for MagicMirror<sup>2</sup> that displays the daily XKCD web comic.
     module: 'DailyXKCD',
 	position: 'top_left',
 	config: {
-		invertColors: true	
+		invertColors: true
 	}
  },
 ```
@@ -23,5 +23,11 @@ A module for MagicMirror<sup>2</sup> that displays the daily XKCD web comic.
 | **Option** | **Description** |
 | --- | --- |
 | `invertColors` | Set to `true` to invert the colors of the comic to white on black for a darker feel. |
+| `updateInterval` | Set to desired update interval (in ms), default is `3600000` (10 hours). |
 | `titleFont` | Set a custom font format, default is `large light bright`. To set the size use one of `xsmall small medium large xlarge`, for boldness one of `thin light regular bold`, and to adjust brightness one of `dimmed normal bright`. |
 | `showAltText` | Set to `true` to show the alt text (tooltip on the original comic). |
+| `altTextFont` | See `titleFont`, except for this is the formatting of the alt text. |
+| `randomComic` | Set to `true`, if you want to see a random comic on days, when there is no new comic. |
+| `limitComicHeight` | Set to limit the height of the comic (in px), default is `450`. The comic will scroll downwards every few seconds, if it is heigher. |
+| `scrollInterval` | How often to scroll long comics (in ms), default is `8000` (every 8 seconds). |
+| `scrollRatio` | Set how much of the visible height is being scrolled every time. The value should be between `0.0` and `1.0`, default is `0.8` so it scrolls down by 80%. |

--- a/node_helper.js
+++ b/node_helper.js
@@ -16,16 +16,25 @@ module.exports = NodeHelper.create({
 			
 			var comicJsonUri = payload.config.dailyJsonUrl;
 
-			var d = new Date();
-			var n = d.getDay();
+			var date = new Date();
+			var dayOfWeek = date.getDay();
 			
 			request(comicJsonUri, function (error, response, body) {
 				if (!error && response.statusCode == 200) {
-					if (n == 1 || n == 3 || n == 5) {
+					if (!payload.config.randomComic) {
+						// if we are not replacing "old" comics with random ones
+						self.sendSocketNotification("COMIC", JSON.parse(body));
+						return;
+					}
+
+					// otherwise select a random comic based on day of week
+					if (dayOfWeek == 1 || dayOfWeek == 3 || dayOfWeek == 5) {
 						self.sendSocketNotification("COMIC", JSON.parse(body));
 					} else {
 						var comic = JSON.parse(body);
-						var randomUrl = "http://xkcd.com/" + Math.floor((Math.random() * comic.num) + 1) + "/info.0.json";
+						var randomNumber = Math.floor((Math.random() * comic.num) + 1);
+						// use "randomNumber = 1732;" to test with long comic
+						var randomUrl = "http://xkcd.com/" + randomNumber + "/info.0.json";
 						request(randomUrl, function (error, response, body) {
 							if (!error && response.statusCode == 200) {
 								self.sendSocketNotification("COMIC", JSON.parse(body));
@@ -34,8 +43,6 @@ module.exports = NodeHelper.create({
 					}
 				}
 			});
-
 		}
-		
 	},
 });

--- a/node_helper.js
+++ b/node_helper.js
@@ -12,19 +12,29 @@ module.exports = NodeHelper.create({
 		var self = this;
 		console.log("Notification: " + notification + " Payload: " + payload);
 		
-		if(notification === "GET_COMIC"){
+		if(notification === "GET_COMIC") {
 			
 			var comicJsonUri = payload.config.dailyJsonUrl;
+
+			var d = new Date();
+			var n = d.getDay();
 			
 			request(comicJsonUri, function (error, response, body) {
 				if (!error && response.statusCode == 200) {
-					console.log(body);
-					self.sendSocketNotification("COMIC", JSON.parse(body));
-					console.log(JSON.parse(body).img);
-					
+					if (n == 1 || n == 3 || n == 5) {
+						self.sendSocketNotification("COMIC", JSON.parse(body));
+					} else {
+						var comic = JSON.parse(body);
+						var randomUrl = "http://xkcd.com/" + Math.floor((Math.random() * comic.num) + 1) + "/info.0.json";
+						request(randomUrl, function (error, response, body) {
+							if (!error && response.statusCode == 200) {
+								self.sendSocketNotification("COMIC", JSON.parse(body));
+							}
+						});
+					}
 				}
 			});
-			
+
 		}
 		
 	},

--- a/xkcd.css
+++ b/xkcd.css
@@ -1,0 +1,22 @@
+/* The basic container */
+.xkcdcontainer {
+    overflow: hidden;
+
+    /* To make the height of the container exact. */
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+}
+
+.xkcdcontent {
+  white-space: nowrap;
+  position: relative;
+  overflow: hidden;    /* Required to make ellipsis work */
+  text-overflow: clip;
+
+  top: 0%;
+  
+  -webkit-transition: top 3s, height 3s;
+  -moz-transition: top 3s, height 3s;
+  transition: top 3s, height 3s;
+}

--- a/xkcd.css
+++ b/xkcd.css
@@ -8,7 +8,7 @@
     box-sizing: border-box;
 }
 
-.xkcdcontent {
+#xkcdcontent {
   white-space: nowrap;
   position: relative;
   overflow: hidden;    /* Required to make ellipsis work */


### PR DESCRIPTION
If the comic is larger, it scrolls downwards in a configurable interval. Since this eats a little bit of CPU, this pauses, if the module is hidden, and also listens for a `USER_PRESENCE` event to automatically stop scrolling from a possible PIR sensor.

Also added options to change appearance in the config, for title and alt text, and to optionally use random comics on days, when there is no new one.
