### PR TITLE
Add ability to choose the width of the comic

### DIFF
--- a/DailyXKCD.js
+++ b/DailyXKCD.js
@@ -9,6 +9,7 @@ Module.register("DailyXKCD", {
         titleFont : "bright large light",
         altTextFont : "xsmall dimmed",
         limitComicHeight : 450,
+        comicWidth : 0,
         scrollInterval : 8000, // 8 seconds,
         scrollRatio : 0.8, // scroll by 80% of visible height,
         randomComic : false,
@@ -93,6 +94,10 @@ Module.register("DailyXKCD", {
         var title = document.createElement("div");
         title.className = this.config.titleFont;
         title.innerHTML = this.dailyComicTitle;
+        if(this.config.comicWidth > 0)
+        {
+            title.style.width = this.config.comicWidth + "px";
+        }
 
         if (this.config.showTitle) {
             wrapper.appendChild(title);
@@ -114,6 +119,11 @@ Module.register("DailyXKCD", {
                                 (this.config.invertColors ? "invert(100%) " : "") +
                                 ";")
         }
+        if(this.config.comicWidth > 0)
+        {
+            xkcd.setAttribute("width", this.config.comicWidth + "px");
+            xkcd.setAttribute("height", "auto");
+        }
         comicWrapper.appendChild(xkcd);
 
         wrapper.appendChild(comicWrapper);
@@ -122,6 +132,10 @@ Module.register("DailyXKCD", {
             var alt = document.createElement("div");
             alt.className = this.config.altTextFont;
             alt.innerHTML = this.dailyComicAlt;
+            if(this.config.comicWidth > 0)
+            {
+                alt.style.width = this.config.comicWidth + "px";
+            }
             wrapper.appendChild(alt);
         }
 
@@ -174,7 +188,7 @@ Module.register("DailyXKCD", {
     scrollComic: function() {
         var scrollable = document.getElementById("xkcdcontent");
 
-        var height = scrollable.naturalHeight;
+        var height = scrollable.height;
 
         var top = 0;
         if (this.config.limitComicHeight > 0 && height > this.config.limitComicHeight)

--- a/DailyXKCD.js
+++ b/DailyXKCD.js
@@ -9,7 +9,7 @@ Module.register("DailyXKCD", {
         titleFont : "bright large light",
         altTextFont : "xsmall dimmed",
         limitComicHeight : 450,
-        comicWidth : 0,
+        limitComicWidth : 0,
         scrollInterval : 8000, // 8 seconds,
         scrollRatio : 0.8, // scroll by 80% of visible height,
         randomComic : false,
@@ -94,14 +94,6 @@ Module.register("DailyXKCD", {
         var title = document.createElement("div");
         title.className = this.config.titleFont;
         title.innerHTML = this.dailyComicTitle;
-        if(this.config.comicWidth > 0)
-        {
-            title.style.width = this.config.comicWidth + "px";
-        }
-
-        if (this.config.showTitle) {
-            wrapper.appendChild(title);
-        }
 
         var comicWrapper = document.createElement("div");
         comicWrapper.className = "xkcdcontainer";
@@ -119,23 +111,44 @@ Module.register("DailyXKCD", {
                                 (this.config.invertColors ? "invert(100%) " : "") +
                                 ";")
         }
-        if(this.config.comicWidth > 0)
-        {
-            xkcd.setAttribute("width", this.config.comicWidth + "px");
-            xkcd.setAttribute("height", "auto");
-        }
-        comicWrapper.appendChild(xkcd);
-
-        wrapper.appendChild(comicWrapper);
 
         if (this.config.showAltText) {
             var alt = document.createElement("div");
             alt.className = this.config.altTextFont;
             alt.innerHTML = this.dailyComicAlt;
-            if(this.config.comicWidth > 0)
+        }
+
+        function limitWidth() {
+
+            var width = this.width;
+
+            // limit comic width if necessary
+            if(this.config.limitComicWidth > 0 && width > this.config.limitComicWidth)
             {
-                alt.style.width = this.config.comicWidth + "px";
+                width = this.config.limitComicWidth;
+                xkcd.setAttribute("width", this.config.limitComicWidth + "px");
+                xkcd.setAttribute("height", "auto");
             }
+            // limit title width
+            if (this.config.limitComicWidth > 0 && this.config.showTitle) {
+                title.style.width = width + "px";
+            }
+            // limit alt text width
+            if (this.config.limitComicWidth > 0 && this.config.showAltText) {
+                alt.style.width = width + "px";
+            }
+        }
+
+        xkcd.config = this.config;
+        xkcd.onload = limitWidth;
+
+        if (this.config.showTitle) {
+            wrapper.appendChild(title);
+        }
+
+        comicWrapper.appendChild(xkcd);
+        wrapper.appendChild(comicWrapper);
+        if (this.config.showAltText) {
             wrapper.appendChild(alt);
         }
 


### PR DESCRIPTION
With the module in `bottom_right` I found that the comic would often overlap with the module in `bottom_left` so I added the `limitComicWidth` option. This resizes the comic to the specified width and adjusts the height proportionally if the comic is going to be too wide. It also limits the width of the title and alt-text to match the comic. I adjusted the `scrollComic` function to work with this option (tested with various tall comics, [like this one](https://xkcd.com/1732/).) This option can be disabled by setting it to zero, which is the default.

Example (limiting comic width to 540px, half of a 1080p display rotated to portrait):
```
{                                                                                                                
    module: 'DailyXKCD',
    position: 'bottom_right',
    config: 
    {
        limitComicWidth: 540,
    }
},
```