### PR TITLE
Fixed issue where the deprecated module 'require' would fail by replacing it with 'https'

### DIFF
--- a/DailyXKCD.js
+++ b/DailyXKCD.js
@@ -2,7 +2,8 @@ Module.register("DailyXKCD", {
 
     // Default module config.
     defaults: {
-        dailyJsonUrl : "http://xkcd.com/info.0.json",
+        hostname : "xkcd.com",
+        dailyJsonUrlPath: "/info.0.json",
         updateInterval : 10000 * 60 * 60, // 10 hours
         grayScale : false,
         invertColors : false,


### PR DESCRIPTION
Request was deprecated, this fixes the require failing when trying to use the module. It also uses the https protocol now which is an added bonus.